### PR TITLE
feat: update project relations by dropping contributorId and tagId, a…

### DIFF
--- a/prisma/migrations/20250916055942_update_project_relations/migration.sql
+++ b/prisma/migrations/20250916055942_update_project_relations/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `contributorId` on the `projects` table. All the data in the column will be lost.
+  - You are about to drop the column `tagId` on the `projects` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."projects" DROP CONSTRAINT "projects_contributorId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."projects" DROP CONSTRAINT "projects_tagId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."projects" DROP COLUMN "contributorId",
+DROP COLUMN "tagId";
+
+-- CreateTable
+CREATE TABLE "public"."project_tags" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "tag_id" TEXT NOT NULL,
+
+    CONSTRAINT "project_tags_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."project_tags" ADD CONSTRAINT "project_tags_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."project_tags" ADD CONSTRAINT "project_tags_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/auth.prisma
+++ b/prisma/schema/auth.prisma
@@ -58,6 +58,7 @@ model Verification {
   @@map("verification")
 }
 
+
 model Project {
   id                  String                @id @default(uuid())
   name                String
@@ -69,26 +70,27 @@ model Project {
   createdAt           DateTime              @default(now()) @map("created_at")
   updatedAt           DateTime              @updatedAt @map("updated_at")
   ProjectContributors ProjectContributors[]
-  project_tags        project_tags[]
+  ProjectTags         ProjectTags[]
 
   @@map("projects")
 }
 
-model project_tags {
-  id         String  @id
-  project_id String
-  tag_id     String
-  projects   Project @relation(fields: [project_id], references: [id], onDelete: Cascade)
-  tags       Tag     @relation(fields: [tag_id], references: [id], onDelete: Cascade)
-}
-
-
 model Tag {
-  id           String         @id @default(uuid())
-  name         String         @unique
-  project_tags project_tags[]
+  id          String        @id @default(uuid())
+  name        String        @unique
+  ProjectTags ProjectTags[]
 
   @@map("tags")
+}
+
+model ProjectTags {
+  id        String  @id @default(uuid())
+  projectId String  @map("project_id")
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  tagId     String  @map("tag_id")
+  tag       Tag     @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@map("project_tags")
 }
 
 model Contributor {


### PR DESCRIPTION
This pull request updates the way projects and tags are related in the database schema. Instead of storing tag and contributor IDs directly on the `projects` table, it introduces a new join table to represent the many-to-many relationship between projects and tags in a more normalized way. The Prisma schema is updated accordingly to reflect these changes.

**Database schema normalization:**

* Removes the `contributorId` and `tagId` columns from the `projects` table, and drops their associated foreign key constraints.
* Creates a new `project_tags` join table to represent the many-to-many relationship between projects and tags, with appropriate foreign key constraints for referential integrity.

**Prisma schema updates:**

* Refactors the Prisma models to replace the old `project_tags` model with a new `ProjectTags` model, and updates the relations in `Project` and `Tag` to use the new model.
* Ensures that the new `ProjectTags` model uses `uuid()` as the default for its `id` and maps its fields to the correct database columns.