### PR TITLE
feat: implemented zod validation and before signup hooks on better auth

### DIFF
--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -1,0 +1,30 @@
+import type { NextFunction, Request, Response } from 'express';
+import { ZodError, type ZodTypeAny } from 'zod';
+import { HTTP } from '@/utils/constants';
+
+export function validateData<T extends ZodTypeAny>(schema: T) {
+    return (req: Request, res: Response, next: NextFunction) => {
+        try {
+            req.body = schema.parse(req.body);
+            next();
+        } catch (error) {
+            if (error instanceof ZodError) {
+                const errorMessages = error.issues.map(issue => ({
+                    field: issue.path.length > 0 ? issue.path.join('.') : 'body',
+                    message: issue.message,
+                    code: issue.code,
+                }));
+
+                res.status(HTTP.BAD_REQUEST).json({
+                    error: 'Invalid data',
+                    details: errorMessages,
+                });
+            } else {
+                console.error('Unexpected error during validation:', error);
+                res
+                    .status(HTTP.INTERNAL)
+                    .json({ error: 'Internal Server Error' });
+            }
+        }
+    };
+}


### PR DESCRIPTION
This pull request introduces a new middleware for validating request data using Zod and enhances the authentication logic to allow setting a user's role during sign-up. The most important changes are grouped below:

**Authentication Enhancements:**

* Added an `after` hook to the `auth` configuration in `src/lib/auth.ts` that uses `createAuthMiddleware` to set the user's role in the database if a `role` is provided during the `/sign-up/email` process.
* Imported `createAuthMiddleware` from `better-auth/plugins` to enable the new authentication hook.

**Validation Middleware:**

* Added a new file `src/middleware/validation.middleware.ts` that exports a `validateData` middleware function. This function uses a Zod schema to validate incoming request bodies, returning detailed error messages on validation failure and handling unexpected errors gracefully.