### PR TITLE
Fix: Test files now run with their specified order under a centralized test file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       run: pnpm prisma generate
     # PACKAGE JSON MA VAKO SCRIPT RUN GARNE 
     # BECAUSE IT IS RUNNING A SINGLE TEST FILE WITH ORDER 
-    - run: pnpm rn test 
+    - run: pnpm run test 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }} # DATABASE URL FROM GITHUB SECRETS
       CI: true # THE CI ENV VARIABLE IS NEEDED FOR VITEST TO RUN IN GITHUB ACTIONS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
     - run: pnpm install
     - name: prisma ko client generate # GENERATE PRISMA CLIENT
       run: pnpm prisma generate
-    - run: pnpm vitest # RUN TESTS
+    # PACKAGE JSON MA VAKO SCRIPT RUN GARNE 
+    # BECAUSE IT IS RUNNING A SINGLE TEST FILE WITH ORDER 
+    - run: pnpm rn test 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }} # DATABASE URL FROM GITHUB SECRETS
       CI: true # THE CI ENV VARIABLE IS NEEDED FOR VITEST TO RUN IN GITHUB ACTIONS

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The API is running at [http://localhost:3000](http://localhost:3000).
 ## Tests
 
 - `npx vitest src/tests/events/create.test.ts` : target a particular file
-- `npx run test` : test all
+- `npm run test` : test all
 
 
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,9 @@ The API is running at [http://localhost:3000](http://localhost:3000).
 ## Tests
 
 - `npx vitest src/tests/events/create.test.ts` : target a particular file
-- `npx vitest` : test all
+- `npx run test` : test all
 
 
-
-` you can also configure to use **npm** in **package.json**`
 
 
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "studio": "prisma studio",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev",
-    "pull": "prisma db pull && prisma generate"
+    "pull": "prisma db pull && prisma generate",
+    "test": "pnpm vitest ./src/tests/order.test.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.15.0",

--- a/src/tests/order.test.ts
+++ b/src/tests/order.test.ts
@@ -1,0 +1,13 @@
+// SEP 18 2025
+// ORDER OF IMPORT MATTERS
+// DO NOT CHANGE THE ORDER OF IMPORT
+// IN **events** THE **eventId** IS SHARED USING SHARED FILE SO PLEASE BE CAREFUL ON CHANGING THE ORDER
+// OF EVENT TEST FILES
+
+import '@/tests/01-events/01-create.test';
+import '@/tests/01-events/02-event.test';
+import '@/tests/01-events/03-update.test';
+import '@/tests/01-events/04-list.test';
+import '@/tests/01-events/05-delete.test';
+import '@/tests/02-member/01-create.test';
+import '@/tests/03-user/01-signin.test';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test:{
     sequence:{
-      // TEST LAI PARALLEL MA RUN NAGAREKO,
-      //  BECAUSE DIFFERENT OPERATION EEUTAI ID MA PANI HUNA SAKXA
-      // THIS IS MORE SAFER AND GOES IN ORDER
-      concurrent: false 
+      // SEEMS LIKE WE DONT NEED THIS ANYMORE
+      // AS WE ARE NOW USING A SINGLE TEST FILE TO IMPORT ALL THE TEST FILES IN ORDER
+      // SO THIS IS NOT REQUIRED
+      // concurrent: false 
     },
     testTimeout: 30000, //  -> EACH TEST
   }


### PR DESCRIPTION
## Previously

> test file was running with vitest builtin file retrieving function which was running the files with previously ran caches and failed logs because of this behaviour the **eventid** was not being properly shared within event test files and because of this the event update and deletion unit tests were being skipped

<img width="695" height="457" alt="skip-test" src="https://github.com/user-attachments/assets/68f3c65f-935b-458c-87fa-5c29e78f1d76" />

## Now

> now with centralized file called `order.test.ts`, it holds all imports for test file in their specified execution order,  i also added a **script** in `package.json` to run the tests in order `pnpm run test`. now with this quick 'hack' we can execute our unit tests with our specified order with working shared variables accross test files tara **pnpm vitest** garo vane it will work by vitest behaviour so unit test execute garda run **pnpm run test** or **npm run test** , single file ko behaviour previous jastai **pnpm vitest <testfile_path>

<img width="637" height="336" alt="correct-test" src="https://github.com/user-attachments/assets/1eff1504-61a7-4400-bd1c-8839af0eaaa5" />


> With this now every single test passed with their **expected** behaviour