### PR TITLE
Update Schema

### DIFF
--- a/prisma/migrations/20250928143026_add_unique_constraints_in_projects/migration.sql
+++ b/prisma/migrations/20250928143026_add_unique_constraints_in_projects/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[github_username]` on the table `contributors` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[project_id,contributor_id]` on the table `project_contributors` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "contributors_github_username_key" ON "public"."contributors"("github_username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_contributors_project_id_contributor_id_key" ON "public"."project_contributors"("project_id", "contributor_id");

--- a/prisma/migrations/20250929035509_add_public_id_in_event_image/migration.sql
+++ b/prisma/migrations/20250929035509_add_public_id_in_event_image/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deleted_at` on the `event_images` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."event_images" DROP COLUMN "deleted_at",
+ADD COLUMN     "public_id" TEXT;

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -109,7 +109,7 @@ model Contributor {
   id                  String                @id @default(uuid())
   name                String
   avatarUrl           String?               @map("avatar_url")
-  githubUsername      String?               @map("github_username")
+  githubUsername      String?               @map("github_username") @unique
   ProjectContributors ProjectContributors[]
 
   @@map("contributors")
@@ -122,6 +122,7 @@ model ProjectContributors {
   contributor   Contributor @relation(fields: [contributorId], references: [id], onDelete: Cascade)
   project       Project     @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
+  @@unique([projectId, contributorId])
   @@map("project_contributors")
 }
 


### PR DESCRIPTION
This pull request introduces important database schema changes to improve data integrity and enforce uniqueness constraints for contributors and project associations. The main updates include adding unique indexes and constraints in both the migration files and the Prisma schema, as well as modifying the `event_images` table.

### Database integrity improvements

* Added a unique constraint to the `github_username` field in the `contributors` table and updated the Prisma schema to enforce uniqueness at the model level. [[1]](diffhunk://#diff-21aca592b1515822c3afe63709c1a33c0ecad95f24125c5a17b2e8c6f73b9475R1-R12) [[2]](diffhunk://#diff-fb8f605b28b6e23e1f305e803113d0acd57c276d012a623195d527129f581b7dL112-R112)
* Added a unique constraint on the combination of `project_id` and `contributor_id` in the `project_contributors` table, ensuring that a contributor cannot be associated with the same project more than once; also reflected in the Prisma schema. [[1]](diffhunk://#diff-21aca592b1515822c3afe63709c1a33c0ecad95f24125c5a17b2e8c6f73b9475R1-R12) [[2]](diffhunk://#diff-fb8f605b28b6e23e1f305e803113d0acd57c276d012a623195d527129f581b7dR125)

### Table structure changes

* Dropped the `deleted_at` column and added a new `public_id` column to the `event_images` table to support new image identification requirements.