### PR TITLE
feat(tag):  implement CRUD operations for tags in the tag controller

### DIFF
--- a/src/controllers/tag.controller.ts
+++ b/src/controllers/tag.controller.ts
@@ -45,6 +45,71 @@ class TagController {
         .json(ErrorResponse(HTTP.INTERNAL, (error as Error).message || "Internal Server Error"));
     }
   }
+  async getTagById(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const tagResult = await tagServices.getTagById(id);
+
+      if (!tagResult.success) {
+        return res.status(HTTP.NOT_FOUND).json(ErrorResponse(HTTP.NOT_FOUND, tagResult.error));
+      }
+
+      return res
+        .status(HTTP.OK)
+        .json(SuccessResponse(HTTP.OK, "Tag fetched successfully", tagResult.data));
+    } catch (error) {
+      console.log(`Get Tag By Id Controller Error: ${error}`);
+      return res
+        .status(HTTP.INTERNAL)
+        .json(ErrorResponse(HTTP.INTERNAL, (error as Error).message || "Internal Server Error"));
+    }
+  }
+
+  async updateTag(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const { name } = req.body;
+      const updateTagResult = await tagServices.updateTag(id, name);
+
+      if (!updateTagResult.success) {
+        return res
+          .status(HTTP.BAD_REQUEST)
+          .json(ErrorResponse(HTTP.BAD_REQUEST, updateTagResult.error));
+      }
+
+      return res
+        .status(HTTP.OK)
+        .json(SuccessResponse(HTTP.OK, "Tag updated successfully", updateTagResult.data));
+    } catch (error) {
+      console.log(`Update Tag Controller Error: ${error}`);
+      return res
+        .status(HTTP.INTERNAL)
+        .json(ErrorResponse(HTTP.INTERNAL, (error as Error).message || "Internal Server Error"));
+    }
+  }
+
+  async deleteTag(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const deleteTagResult = await tagServices.deleteTag(id);
+
+      if (!deleteTagResult.success) {
+        return res
+          .status(HTTP.BAD_REQUEST)
+          .json(ErrorResponse(HTTP.BAD_REQUEST, deleteTagResult.error));
+      }
+
+      return res
+        .status(HTTP.OK)
+        .json(SuccessResponse(HTTP.OK, "Tag deleted successfully", deleteTagResult.data));
+    } catch (error) {
+      console.log(`Delete Tag Controller Error: ${error}`);
+      return res
+        .status(HTTP.INTERNAL)
+        .json(ErrorResponse(HTTP.INTERNAL, (error as Error).message || "Internal Server Error"));
+    }
+  }
 }
+
 
 export const tagController = new TagController();

--- a/src/routers/tag.router.ts
+++ b/src/routers/tag.router.ts
@@ -6,8 +6,9 @@ const tagRouter = Router();
 
 tagRouter.use(authMiddleware, isModerator);
 
-// Private Routes
 tagRouter.get("/", tagController.getAllTags);
+tagRouter.get("/:id", tagController.getTagById);
 tagRouter.post("/", tagController.createTag);
-
+tagRouter.patch("/:id", tagController.updateTag);
+tagRouter.delete("/:id", tagController.deleteTag);
 export default tagRouter;

--- a/src/services/tag.service.ts
+++ b/src/services/tag.service.ts
@@ -133,6 +133,74 @@ class TagServices {
       return { success: false, error: "Internal server error" };
     }
   }
+   async getTagById(id: string) {
+    try {
+      const [error, result] = await prismaSafe(
+        prisma.tag.findUnique({
+          where: {
+            id,
+          },
+        })
+      );
+      if (error) {
+        return { success: false, error: error };
+      }
+      if (!result) {
+        return { success: false, error: "Tag not found" };
+      }
+      return { success: true, data: result };
+    } catch (error) {
+      console.log(`Failed to fetch tag by id, ${error}`);
+      return { success: false, error: error };
+    }
+  }
+
+  async updateTag(id: string, name: string) {
+    try {
+      const [error, result] = await prismaSafe(
+        prisma.tag.update({
+          where: {
+            id,
+          },
+          data: {
+            name,
+          },
+        })
+      );
+      if (error) {
+        return { success: false, error: error };
+      }
+      if (!result) {
+        return { success: false, error: "Failed to update tag" };
+      }
+      return { success: true, data: result };
+    } catch (error) {
+      console.log(`Failed to update tag, ${error}`);
+      return { success: false, error: error };
+    }
+  }
+
+  async deleteTag(id: string) {
+    try {
+      const [error, result] = await prismaSafe(
+        prisma.tag.delete({
+          where: {
+            id,
+          },
+        })
+      );
+      if (error) {
+        return { success: false, error: error };
+      }
+      if (!result) {
+        return { success: false, error: "Failed to delete tag" };
+      }
+      return { success: true, data: result };
+    } catch (error) {
+      console.log(`Failed to delete tag, ${error}`);
+      return { success: false, error: error };
+    }
+  }
 }
 
 export const tagServices = new TagServices();


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) support for tags in the backend. The main changes include new controller methods, service functions, and router endpoints for retrieving, updating, and deleting tags by ID.

**Tag CRUD operations:**

* Added `getTagById`, `updateTag`, and `deleteTag` methods to the `TagController` class in `src/controllers/tag.controller.ts`, enabling fetching, updating, and deleting tags by their ID.
* Implemented corresponding service methods `getTagById`, `updateTag`, and `deleteTag` in `TagServices` within `src/services/tag.service.ts` to handle database operations for these actions.

**Routing updates:**

* Updated `src/routers/tag.router.ts` to add new routes for getting, updating, and deleting tags by ID (`GET /:id`, `PATCH /:id`, `DELETE /:id`).