### PR TITLE
Feat: Implement getProjectById

### DIFF
--- a/prisma/migrations/20251019183732_normalize_column_name_projects_table/migration.sql
+++ b/prisma/migrations/20251019183732_normalize_column_name_projects_table/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tech_stack` on the `projects` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."projects" DROP COLUMN "tech_stack",
+ADD COLUMN     "techStacks" TEXT[];

--- a/prisma/migrations/20251020025619_update_description_type_projects/migration.sql
+++ b/prisma/migrations/20251020025619_update_description_type_projects/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `techStacks` on the `projects` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."projects" DROP COLUMN "techStacks",
+ADD COLUMN     "tech_stacks" TEXT[];

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -76,8 +76,8 @@ model Project {
   name                String
   githubLink          String?               @map("github_link")
   demoLink            String?               @map("demo_link")
-  techStacks          String[]              
-  description         String
+  techStacks          String[]              @map("tech_stacks")
+  description         String                @db.Text
   thumbnailUrl        String?               @map("thumbnail_url")
   createdAt           DateTime              @default(now()) @map("created_at")
   updatedAt           DateTime              @updatedAt @map("updated_at")

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -76,7 +76,7 @@ model Project {
   name                String
   githubLink          String?               @map("github_link")
   demoLink            String?               @map("demo_link")
-  tech_stack          String[]
+  techStacks          String[]              
   description         String
   thumbnailUrl        String?               @map("thumbnail_url")
   createdAt           DateTime              @default(now()) @map("created_at")
@@ -109,7 +109,7 @@ model Contributor {
   id                  String                @id @default(uuid())
   name                String
   avatarUrl           String?               @map("avatar_url")
-  githubUsername      String?               @map("github_username") @unique
+  githubUsername      String?               @unique @map("github_username")
   ProjectContributors ProjectContributors[]
 
   @@map("contributors")
@@ -148,17 +148,17 @@ model EventSchedule {
   @@map("event_schedule")
 }
 
-model EventImage{
-    id          String          @id @default(uuid())
-    imageUrl    String?          @map("image_url") 
-    imageType   EventImageType  @map("image_type")
-    uploadedAt  DateTime        @default(now()) @map("uploaded_at")
-    publicId    String?         @map("public_id")
-    eventId     String          @map("event_id")
-    event       Events          @relation(fields: [eventId], references: [id], onDelete: Cascade)
+model EventImage {
+  id         String         @id @default(uuid())
+  imageUrl   String?        @map("image_url")
+  imageType  EventImageType @map("image_type")
+  uploadedAt DateTime       @default(now()) @map("uploaded_at")
+  publicId   String?        @map("public_id")
+  eventId    String         @map("event_id")
+  event      Events         @relation(fields: [eventId], references: [id], onDelete: Cascade)
 
-    @@map("event_images")
-  }
+  @@map("event_images")
+}
 
 model member {
   id        String       @id @default(uuid())
@@ -220,8 +220,8 @@ enum EventStatus {
   COMPLETED
 }
 
-enum EventImageType{
-    PROMOTIONAL
-    GALLERY
-    GUESTS
-  }
+enum EventImageType {
+  PROMOTIONAL
+  GALLERY
+  GUESTS
+}

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -43,6 +43,25 @@ class ProjectController {
     }
   }
 
+  async getProjectById(req: Request, res: Response) {
+    try {
+      const projectId = req.params.id;
+      const projectResult = await projectServices.getProjectById(projectId);
+
+      if (!projectResult.success || !projectResult.data) {
+        return res
+          .status(HTTP.BAD_REQUEST)
+          .json(ErrorResponse(HTTP.BAD_REQUEST, projectResult.error || 'Project not found'));
+      }
+
+      return res
+        .status(HTTP.OK)
+        .json(SuccessResponse(HTTP.OK, 'Project fetched successfully', projectResult.data));
+    } catch (error) {
+      console.error('Error in getProjectById controller:', error);
+      res.status(HTTP.INTERNAL).json(ErrorResponse(HTTP.INTERNAL, 'Internal Server Error'));
+    }
+  }
   async addProject(req: Request, res: Response) {
     try {
       const { name, githubLink, demoLink, description, techStacks, tagIds }: CreateProjectInput =
@@ -163,28 +182,23 @@ class ProjectController {
 
   async uploadImage(req: Request, res: Response) {
     try {
-      if (!req.file) return res
-      .status(HTTP.BAD_REQUEST)
-      .json(
-        ErrorResponse(HTTP.BAD_REQUEST, "Image is required")
-      )
-        const image = req.file;
-        
-        const uploadResult = await uploadImageToCloudinary(image!.path, {folder: "projects"})
-        if (!uploadResult.success) {
-          return res
-          .status(HTTP.BAD_REQUEST)
-          .json(
-            ErrorResponse(HTTP.BAD_REQUEST, uploadResult.error|| 'Failed to upload image.')
-          );
-        }
+      if (!req.file)
         return res
-          .status(HTTP.OK)
-          .json(
-            SuccessResponse(HTTP.OK,"Uploaded successfully", uploadResult.url)
-          );
+          .status(HTTP.BAD_REQUEST)
+          .json(ErrorResponse(HTTP.BAD_REQUEST, 'Image is required'));
+      const image = req.file;
+
+      const uploadResult = await uploadImageToCloudinary(image!.path, { folder: 'projects' });
+      if (!uploadResult.success) {
+        return res
+          .status(HTTP.BAD_REQUEST)
+          .json(ErrorResponse(HTTP.BAD_REQUEST, uploadResult.error || 'Failed to upload image.'));
+      }
+      return res
+        .status(HTTP.OK)
+        .json(SuccessResponse(HTTP.OK, 'Uploaded successfully', uploadResult.url));
     } catch (error) {
-      console.log("Error whole uploading image: ", error)
+      console.log('Error whole uploading image: ', error);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ const port = process.env.PORT || 3000;
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const corsOptions = {
   origin: process.env.CORS_ORIGIN || '',
-  methods: ['GET', 'POST', 'OPTIONS'],
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],
   credentials: true,
 };

--- a/src/routers/project.router.ts
+++ b/src/routers/project.router.ts
@@ -9,13 +9,14 @@ import {
 import { authMiddleware, isModerator } from '@/middleware/auth.middleware';
 import { validateBody, validateParams, validateQuery } from '@/middleware/validation.middleware';
 import { Router } from 'express';
+import router from './user.router';
 
 const projectRouter = Router();
 
 // Public route
 projectRouter.get('/', validateQuery(paginationQuerySchema), projectController.getAllProjects);
-
-projectRouter.use(authMiddleware);
+projectRouter.get("/:id", validateParams(projectIdParamsSchema), projectController.getProjectById);
+projectRouter.use(authMiddleware, isModerator);
 
 // Private Routes
 projectRouter.post(

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -8,19 +8,8 @@ class GithubServices {
     repoName: string
   ): Promise<{ success: boolean; data?: GithubContributor[]; error?: string }> {
     try {
-      const token = process.env.GITHUB_TOKEN;
-      if (!token) {
-        console.log('No github token found');
-        return { success: false, error: 'No GitHub token found' };
-      }
       const repositoryResponse = await axios.get(
-        `https://api.github.com/repos/BIC-Devsphere/${repoName}/contributors`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'X-GitHub-Api-Version': '2022-11-28',
-          },
-        }
+        `https://api.github.com/repos/BIC-Devsphere/${repoName}/contributors`
       );
 
       const [error, contributors] = await prismaSafe(

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -7,6 +7,7 @@ import { tagServices } from './tag.service';
 import type { CreateProjectInput, UpdateProjectInput } from '@/lib/zod/project.schema';
 import cloudinary from '@/lib/cloudinary';
 import { uploadImageToCloudinary } from '@/utils/cloudinary.uploader';
+import { mapProjects } from '@/utils/project.mapper';
 
 class ProjectServices {
   async getAllProjects({ skip, limit }: { skip?: number; limit?: number }) {
@@ -53,23 +54,52 @@ class ProjectServices {
 
       const [projects, total] = projectsResult;
 
-      const mappedProjects: GetAllProjects[] = projects.map((project) => ({
-        id: project.id,
-        name: project.name,
-        githubLink: project.githubLink,
-        demoLink: project.demoLink,
-        thumbnailUrl: project.thumbnailUrl,
-        tech_stack: project.tech_stack,
-        description: project.description,
-        tags: project.ProjectTags.map((pt) => pt.tag),
-        contributors: project.ProjectContributors.map((pc) => pc.contributor),
-        createdAt: project.createdAt,
-        updatedAt: project.updatedAt,
-      }));
+      const mappedProjects = mapProjects(projects);
 
       return { success: true, data: { mappedProjects, total } };
     } catch (error) {
       console.error('Error fetching projects:', error);
+      return { success: false, error: error };
+    }
+  }
+
+  async getProjectById(projectId: string) {
+    try {
+      const [error, projectResult] = await prismaSafe(
+        prisma.project.findUnique({
+          where: { id: projectId },
+          include: {
+            ProjectTags: {
+              select: {
+                tag: true,
+              },
+            },
+            ProjectContributors: {
+              select: {
+                contributor: {
+                  select: {
+                    id: true,
+                    name: true,
+                    avatarUrl: true,
+                    githubUsername: true,
+                  },
+                },
+              },
+            },
+          },
+        })
+      );
+      if (error) {
+        return { success: false, error };
+      }
+      if (!projectResult) {
+        return { success: false, error: 'Project not found' };
+      }
+
+      const mappedProject = mapProjects([projectResult])[0];
+      return { success: true, data: mappedProject };
+    } catch (error) {
+      console.error('Error fetching project by ID:', error);
       return { success: false, error: error };
     }
   }
@@ -102,7 +132,7 @@ class ProjectServices {
             demoLink: project.demoLink,
             description: project.description,
             thumbnailUrl: thumbnailUrl,
-            tech_stack: project.techStacks,
+            techStacks: project.techStacks,
           },
         })
       );
@@ -222,7 +252,6 @@ class ProjectServices {
       return { success: false, error };
     }
   }
-
 }
 
 export const projectServices = new ProjectServices();

--- a/src/utils/project.mapper.ts
+++ b/src/utils/project.mapper.ts
@@ -26,7 +26,7 @@ export const mapProjects = (projects: ProjectWithRelations[]) => {
     githubLink: project.githubLink,
     demoLink: project.demoLink,
     thumbnailUrl: project.thumbnailUrl,
-    tech_stack: project.techStacks,
+    techStacks: project.techStacks,
     description: project.description,
     tags: project.ProjectTags.map((pt) => pt.tag),
     contributors: project.ProjectContributors.map((pc) => pc.contributor),

--- a/src/utils/project.mapper.ts
+++ b/src/utils/project.mapper.ts
@@ -1,0 +1,36 @@
+import type { GetAllProjects } from '@/types/project.types';
+import { Prisma, type Project } from '@prisma/client';
+
+type ProjectWithRelations = Prisma.ProjectGetPayload<{
+  include: {
+    ProjectTags: { select: { tag: true } };
+    ProjectContributors: {
+      select: {
+        contributor: {
+          select: {
+            id: true;
+            name: true;
+            avatarUrl: true;
+            githubUsername: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
+export const mapProjects = (projects: ProjectWithRelations[]) => {
+  return projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    githubLink: project.githubLink,
+    demoLink: project.demoLink,
+    thumbnailUrl: project.thumbnailUrl,
+    tech_stack: project.techStacks,
+    description: project.description,
+    tags: project.ProjectTags.map((pt) => pt.tag),
+    contributors: project.ProjectContributors.map((pc) => pc.contributor),
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+  }));
+};


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the project management backend, focusing on normalizing database schema, improving API functionality, and enhancing code maintainability. The most significant changes are the normalization of the `tech_stack` column name, the addition of a new endpoint to fetch a project by its ID, and the introduction of a dedicated mapper utility for project entities.

**Database Schema Normalization:**

* Renamed the column `tech_stack` to `techStacks` in the `projects` table and updated the Prisma schema accordingly, ensuring consistent naming conventions across the codebase. [[1]](diffhunk://#diff-2e9423f8a0b99d3ad68deb83109efc3923389000f90e5f91a39f21933fffb9d4R1-R9) [[2]](diffhunk://#diff-fb8f605b28b6e23e1f305e803113d0acd57c276d012a623195d527129f581b7dL79-R79)
* Minor adjustment to the `githubUsername` field mapping in the `Contributor` model to maintain Prisma best practices.

**API Enhancements:**

* Added a new `GET /projects/:id` endpoint in `project.router.ts` and its corresponding controller method to allow fetching a single project by ID, including related tags and contributors.

**Codebase Refactoring:**

* Introduced a new utility function `mapProjects` in `project.mapper.ts` to centralize and standardize the mapping of project entities, replacing inline mapping logic in the service layer.
* Improved formatting and error handling in the `uploadImage` controller for better readability and consistency.